### PR TITLE
Fix hold item valuation lookup

### DIFF
--- a/src/team/domain/persistence/team.repository.ts
+++ b/src/team/domain/persistence/team.repository.ts
@@ -258,15 +258,28 @@ export class TeamRepository implements TeamDomainReader, TeamDomainWrtier {
         const classItems = team.class.classItems;
 
         const newHoldItems = holdItems.map((holdItem) => {
-            const classItem = classItems.filter((item) => item.itemId === holdItem.itemId);
-            const nowMoney = classItem[0].money[teamClass.curInvDeg + 1];
+            const classItem = classItems.find((item) => item.itemId === holdItem.itemId);
+
+            if (!classItem) {
+                throw new NotFoundException(
+                    `해당하는 id(${holdItem.itemId})의 수업 종목 정보가 존재하지 않습니다.`
+                );
+            }
+
+            const priceIndex = teamClass.curInvDeg + 1;
+            const nowMoney =
+                classItem.money[priceIndex] ??
+                classItem.money[classItem.money.length - 1];
+
             const valMoney = nowMoney * holdItem.itemCnt;
             const valProfit = valMoney - holdItem.totalMoney;
             const profitNum = (valProfit / holdItem.totalMoney) * 100;
+
             holdItem.nowMoney = nowMoney;
             holdItem.valMoney = valMoney;
             holdItem.valProfit = valProfit;
             holdItem.profitNum = profitNum;
+
             return holdItem;
         });
 


### PR DESCRIPTION
## Summary
- handle missing class items when updating hold holdings
- lookup price with `find` instead of `filter`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685211b5c3b8832c83249953dad3419d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 보유 아이템의 클래스 데이터 조회 및 검증이 개선되어, 일치하는 클래스 아이템이 없을 경우 오류가 발생하도록 수정되었습니다.
  - 가격 정보 접근 시, 유효한 인덱스가 없을 경우 마지막 가격을 안전하게 참조하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->