### PR TITLE
Add API to get team orders per stage

### DIFF
--- a/src/team/application/impl/team.read.service.impl.ts
+++ b/src/team/application/impl/team.read.service.impl.ts
@@ -48,4 +48,11 @@ export class TeamReadServiceImpl implements TeamReadService {
     async getTeamInvOrderById(teamId: number): Promise<TeamOrderDTO[]> {
         return await this.reader.findTeamInvOrderById(teamId);
     }
+
+    async getTeamOrderByInvDeg(
+        teamId: number,
+        invDeg: number
+    ): Promise<TeamOrderDTO[]> {
+        return await this.reader.findTeamOrderByInvDeg(teamId, invDeg);
+    }
 }

--- a/src/team/application/team.read.service.ts
+++ b/src/team/application/team.read.service.ts
@@ -13,4 +13,8 @@ export interface TeamReadService {
 
     // 기관용
     getTeamInvOrderById(teamId: number): Promise<TeamOrderDTO[]>;
+    getTeamOrderByInvDeg(
+        teamId: number,
+        invDeg: number
+    ): Promise<TeamOrderDTO[]>;
 }

--- a/src/team/domain/persistence/team.repository.ts
+++ b/src/team/domain/persistence/team.repository.ts
@@ -110,6 +110,27 @@ export class TeamRepository implements TeamDomainReader, TeamDomainWrtier {
         return await Promise.all(orders.map((order) => this.mapper.toTeamOrderDomain(order)));
     }
 
+    async findTeamOrderByInvDeg(
+        teamId: number,
+        invDeg: number
+    ): Promise<TeamOrderDTO[]> {
+        const orders = await this.orderTypeormRepository.find({
+            where: {
+                invDeg: invDeg,
+                team: {
+                    id: teamId
+                }
+            },
+            order: {
+                id: 'ASC'
+            }
+        });
+
+        return await Promise.all(
+            orders.map((order) => this.mapper.toTeamOrderDomain(order))
+        );
+    }
+
     async save(teamDTO: TeamDTO, classId: number): Promise<[TeamDTO, number]> {
         const team = await this.mapper.toTeamEntity(teamDTO);
 

--- a/src/team/domain/team.domain.reader.ts
+++ b/src/team/domain/team.domain.reader.ts
@@ -11,4 +11,8 @@ export interface TeamDomainReader {
 
     // 기관용
     findTeamInvOrderById(teamId: number): Promise<TeamOrderDTO[]>;
+    findTeamOrderByInvDeg(
+        teamId: number,
+        invDeg: number
+    ): Promise<TeamOrderDTO[]>;
 }

--- a/src/team/presentation/team.read.adapter.ts
+++ b/src/team/presentation/team.read.adapter.ts
@@ -73,6 +73,16 @@ export class TeamReadAdapter {
     async getClassTeam(@Param('id', ParseIntPipe) teamId: number): Promise<TeamOrderDTO[]> {
         return await this.readService.getTeamInvOrderById(teamId);
     }
+
+    @Get('/:id/:deg')
+    @UseGuards(JwtAuthGuard)
+    @Permission([Authority.ORGAN])
+    async getClassTeamByInvDeg(
+        @Param('id', ParseIntPipe) teamId: number,
+        @Param('deg', ParseIntPipe) deg: number
+    ): Promise<TeamOrderDTO[]> {
+        return await this.readService.getTeamOrderByInvDeg(teamId, deg);
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary
- support fetching team order list per investment stage
- expose new endpoint `GET /team/:id/:deg` for organ users

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68521615c304832c8eecd9bfb8f2d97c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 특정 팀 ID와 투자 등급(invDeg)으로 팀 주문 정보를 조회할 수 있는 새로운 GET 엔드포인트가 추가되었습니다.
	- 투자 등급을 기준으로 팀 주문 정보를 조회하는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->