### PR TITLE
Fix unexpected CLASS_CANCEL broadcast

### DIFF
--- a/src/common/sse/sse.service.ts
+++ b/src/common/sse/sse.service.ts
@@ -73,7 +73,6 @@ export class SseService implements OnModuleDestroy {
 
         res.on('close', () => {
             this.cleanupClient(res);
-            this.sendToAllStudents(EventType.CLASS_CANCEL, new EventClassCancelForm(classId));
             this.removeTeacherClient(classId, res);
         });
 


### PR DESCRIPTION
## Summary
- prevent broadcasting `CLASS_CANCEL` when a teacher's SSE connection closes unintentionally

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521423614c832cbab0259d0489e64b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 교사 클라이언트 연결이 종료될 때 더 이상 모든 학생에게 수업 취소 알림이 전송되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->