### PR TITLE
Add admin team holdings endpoint

### DIFF
--- a/src/team/presentation/team.read.adapter.ts
+++ b/src/team/presentation/team.read.adapter.ts
@@ -74,6 +74,13 @@ export class TeamReadAdapter {
         return await this.readService.getTeamInvOrderById(teamId);
     }
 
+    @Get('/:id/holdItems')
+    @UseGuards(JwtAuthGuard)
+    @Permission([Authority.ORGAN])
+    async getClassTeamHoldItems(@Param('id', ParseIntPipe) teamId: number): Promise<HoldItemDTO[]> {
+        return await this.readService.getTeamHoldItemById(teamId);
+    }
+
     @Get('/:id/:deg')
     @UseGuards(JwtAuthGuard)
     @Permission([Authority.ORGAN])


### PR DESCRIPTION
## Summary
- allow admin to query a team's current stock holdings

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858f6f4c308832cba333c2e8e527005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 조직 권한 사용자가 팀 ID로 특정 팀의 보류 항목을 조회할 수 있는 새로운 GET 엔드포인트(`/team/:id/holdItems`)가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->